### PR TITLE
Fix flit_core build requires/backend.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["flit"]
-build-backend = "flit.buildapi"
+requires = ["flit_core"]
+build-backend = "flit_core.buildapi"
 
 [tool.flit.metadata]
 module = "github_bot"


### PR DESCRIPTION
Only flit_core should be required by pyproject.toml, the regular flit package is the pep517 frontend which is not what should be set for the build system.

<!-- Thank you for your contribution! -->

## What do these changes do?

Fixes flit_core build requires/backend.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

Fixes flit build requirements.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [n/a] Unit tests for the changes exist
- [n/a] Documentation reflects the changes
- [n/a] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
